### PR TITLE
Set up SQLite database with users, products, and orders tables (#16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,7 @@ src/generated/
 
 ### Distribution ###
 distributions
+
+### Database ###
+*.db
+.idea/

--- a/src/main/java/MainApp.java
+++ b/src/main/java/MainApp.java
@@ -1,10 +1,12 @@
 import javafx.application.Application;
 import javafx.stage.Stage;
+import database.DatabaseManager;
 
 public class MainApp extends Application {
 
     @Override
     public void start(Stage primaryStage) {
+        DatabaseManager.initializeDatabase();
         SceneFactory factory = new SceneFactory(primaryStage);
 
         primaryStage.setTitle("E-Commerce App");

--- a/src/main/java/database/DatabaseManager.java
+++ b/src/main/java/database/DatabaseManager.java
@@ -1,0 +1,53 @@
+package database;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class DatabaseManager {
+
+    private static final String DB_URL = "jdbc:sqlite:ecommerce.db";
+
+    public static Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(DB_URL);
+    }
+
+    public static void initializeDatabase() {
+        String createUsers =
+                "CREATE TABLE IF NOT EXISTS users ("
+                        + "user_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                        + "username TEXT UNIQUE NOT NULL, "
+                        + "password TEXT NOT NULL, "
+                        + "role TEXT NOT NULL)";
+
+        String createProducts =
+                "CREATE TABLE IF NOT EXISTS products ("
+                        + "product_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                        + "name TEXT NOT NULL, "
+                        + "description TEXT, "
+                        + "price REAL NOT NULL, "
+                        + "stock INTEGER NOT NULL)";
+
+        String createOrders =
+                "CREATE TABLE IF NOT EXISTS orders ("
+                        + "order_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                        + "user_id INTEGER NOT NULL, "
+                        + "product_id INTEGER NOT NULL, "
+                        + "quantity INTEGER NOT NULL, "
+                        + "status TEXT NOT NULL, "
+                        + "order_date TEXT, "
+                        + "price_at_purchase REAL, "
+                        + "FOREIGN KEY (user_id) REFERENCES users(user_id), "
+                        + "FOREIGN KEY (product_id) REFERENCES products(product_id))";
+
+        try (Connection conn = getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute(createUsers);
+            stmt.execute(createProducts);
+            stmt.execute(createOrders);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Closes #16

Sets up SQLite with the initial three tables the application will use.

Changes:
- Created DatabaseManager class that connects to ecommerce.db and creates the users, products, and orders tables on run
- Called DatabaseManager.initializeDatabase() from MainApp so tables are created when the app launches
- Added *.db and .idea/ to .gitignore

Tested by running the app and confirming all three tables appear in ecommerce.db.